### PR TITLE
VP-1249__Fix_login_form_action

### DIFF
--- a/snippets/customers/login-form.liquid
+++ b/snippets/customers/login-form.liquid
@@ -1,4 +1,4 @@
-<form accept-charset="UTF-8" action="{{ '~/account/login' | absolute_url }}" method="post" id="customer_login" name="customer_login">
+<form accept-charset="UTF-8" action="{{ requestUrl }}" method="post" id="customer_login" name="customer_login">
 {% include 'form-errors-custom' %}
 <fieldset>
     <div class="form-group">


### PR DESCRIPTION
Used requestUrl instead of hardcoded '~/account/login' to save params