### PR TITLE
VP-1289: Use passed loginUrl in login-form

### DIFF
--- a/snippets/customers/login-form.liquid
+++ b/snippets/customers/login-form.liquid
@@ -1,4 +1,4 @@
-<form accept-charset="UTF-8" action="{{ requestUrl }}" method="post" id="customer_login" name="customer_login">
+<form accept-charset="UTF-8" action="{{ loginUrl }}" method="post" id="customer_login" name="customer_login">
 {% include 'form-errors-custom' %}
 <fieldset>
     <div class="form-group">

--- a/snippets/index/asides.liquid
+++ b/snippets/index/asides.liquid
@@ -7,6 +7,7 @@
 <aside class="panel panel-default" ng-if="customer && !customer.isRegisteredUser">
     <div class="panel-body">
         <h4>{{ 'customer.sign-in.title' | t }}</h4>
+        {% capture loginUrl %} {{ '~/account/login' | absolute_url }} {% endcapture %}
         {% include 'customers/login-form' %}
     </div>
 </aside>

--- a/templates/customers/login.liquid
+++ b/templates/customers/login.liquid
@@ -3,6 +3,7 @@
         <div class="row">
             <div class="col-md-4">
                 <h1>{{ 'customer.sign-in.title' | t }}</h1>
+                {% capture loginUrl %} {{ requestUrl }} {% endcapture %}
                 {% include 'customers/login-form' %}
             </div>
             <div class="col-md-8">


### PR DESCRIPTION
Need to pass correct loginUrl from the places we are using login form:
- `account/login` for main form;
- `requestUrl` for login form, to preserve params;